### PR TITLE
Handle routes with optional wildcards

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = function sortRouteAddresses (addresses, options) {
           seenWildcard = true;
         }
         // Add a `2` for each param.
-        else if (components[i][0] === ':' || components[i] === '?:') {
+        else if (components[i][0] === ':') {
           rank += '2';
         }
         // Add a `1` for each static path component.

--- a/index.js
+++ b/index.js
@@ -93,13 +93,13 @@ module.exports = function sortRouteAddresses (addresses, options) {
       // at least `i+1` components)...
       if (components[i]) {
         // Add a '3' for each wildcard.
-        if (components[i] === '*') {
+        if (components[i] === '*' || components[i] === '?*') {
           rank += '3';
           // Indicate that this address has a wildcard.
           seenWildcard = true;
         }
         // Add a `2` for each param.
-        else if (components[i][0] === ':') {
+        else if (components[i][0] === ':' || components[i] === '?:') {
           rank += '2';
         }
         // Add a `1` for each static path component.


### PR DESCRIPTION
This PR adds a check for optional wildcards when ranking routes. 

For example:
```
// route with wildcard
  'GET /bar/*': {
    action: 'view-bar',
  },
// Route with optional wildcard
  'GET /foo/?*': {
    action: 'view-foo',
   },
// Redirects
'GET /bar/foo': '/legal',
'GET /foo/bar': '/foo/baz',
```
### Current behavior:
Currently, optional wildcard routes are not being ranked properly 
The `/bar/foo` redirect that handles the wildcard route would work as expected, but the optional wildcard route would take precedence over the `/foo/bar` redirect.

### Behavior with this change:
The explicitly set redirects will take precedence over all wildcard routes




